### PR TITLE
Fix convert_default always overwriting user-provided value. Fixes #29

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Contributors
 * Chris Angelico <rosuav@gmail.com>
 * Karan Parikh <karanparikh1991@gmail.com>
 * Kevin Samuel <kevin@yeleman.com>
+* Konstantinos Koukopoulos <kouk@transifex.com>

--- a/clize/parameters.py
+++ b/clize/parameters.py
@@ -226,14 +226,18 @@ class _SubBoundArguments(object):
     posarg_only = _ComposedProperty('posarg_only')
     skip = _ComposedProperty('skip')
     unsatisfied = _ComposedProperty('unsatisfied')
+    not_provided = _ComposedProperty('not_provided')
 
 
 class _DerivBoundArguments(object):
     def __init__(self, deriv, real):
         self.real = real
         u = self.unsatisfied = set()
+        n = self.not_provided = set()
         if deriv.sub_required:
             u.add(deriv)
+        else:
+            n.add(deriv)
 
     args = _ComposedProperty('args')
     kwargs = _ComposedProperty('kwargs')
@@ -290,6 +294,7 @@ class _DapMeta(object):
         if self.sub is None:
             fba = self.sub = _SubBoundArguments(self.ba)
             self.ba.unsatisfied.update(self.parent.cli.required)
+            self.ba.not_provided.update(self.parent.cli.optional)
             return fba
         else:
             return self.sub

--- a/clize/parser.py
+++ b/clize/parser.py
@@ -1121,6 +1121,11 @@ class CliBoundArguments(object):
 
        Required parameters that haven't yet been satisfied.
 
+    .. attribute:: not_provided
+       :annotation: = set(sig.optional)
+
+       Optional parameters that haven't yet received a value.
+
     .. attribute:: sticky
        :annotation: = None
 

--- a/clize/parser.py
+++ b/clize/parser.py
@@ -316,7 +316,8 @@ class ParameterWithValue(Parameter):
             pass
         else:
             if self.default != util.UNSET and info['convert_default']:
-                self.set_value(ba, self.coerce_value(self.default, ba))
+                if self in ba.not_provided:
+                    self.set_value(ba, self.coerce_value(self.default, ba))
 
 
 class NamedParameter(Parameter):

--- a/clize/tests/test_parser.py
+++ b/clize/tests/test_parser.py
@@ -392,6 +392,14 @@ class SigTests(Fixtures):
         sig = support.s('*, par:conv="default"', locals={'conv': conv})
         self._do_test(sig, '[--par=CONV]', (), [], {})
 
+    def test_vconverter_convert_value(self):
+        @parser.value_converter(convert_default=True)
+        def conv(arg):
+            return 'c{}c'.format(arg)
+        sig = support.s('*, par:conv="default"', locals={'conv': conv})
+        self._do_test(sig, '[--par=CONV]', ('--par=A',), [], {'par': 'cAc'})
+        self._do_test(sig, '[--par=CONV]', ('--par', 'A',), [], {'par': 'cAc'})
+
     def test_vconverter_convert_default(self):
         @parser.value_converter(convert_default=True)
         def conv(arg):


### PR DESCRIPTION
Changes made to clize.parser.CliBoundArguments in c2b5b85 are, AFAICS, the cause of #29  because `OptionParameter.post_parse` is being called for all parameters [here](https://github.com/epsy/clize/blob/master/clize/parser.py#L1213-L1214). When `convert_default` is `True` (like it is for `clize.converters.file`) this leads to the value being always overwritten with the default.

In this PR I added support for recording which parameters did not receive at least one value, on a new attribute `CliBoundArguments.not_provided`. And then in `ParameterWithValue.post_parse` I check this and only replace the value with the default if at least one value was not provided.

Also worth noting is that we only consider the complement of the required parameters, i.e. we only consider parameters where `.required` is either unset or un-True. This as an optimization since a default value doesn't make sense for them and if they are not provided then that's an error.