### PR TITLE
Fixed issue #37 (Windows issue) invoking os.path.relpath(path)

### DIFF
--- a/clize/runner.py
+++ b/clize/runner.py
@@ -300,7 +300,10 @@ def get_executable(path, default):
     else:
         if which(basename) == path:
             return basename
-    rel = os.path.relpath(path)
+    try:
+        rel = os.path.relpath(path)
+    except ValueError:
+        return basename
     if rel.startswith('../'):
         if which is None and os.path.isabs(path):
             return basename


### PR DESCRIPTION
Fixed issue #37 (Windows issue), where invoking os.path.relpath(path) raises a ValueError when the path of the executable is on a different drive than the current directory, Returning basedir as executable name seems appropriate in this case.