### PR TITLE
tox.ini: mitigate version incompatibility between coveralls and coverage 5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ deps=
     Pygments
     docs: sphinx
     docs: sphinx_rtd_theme
-    cover,coveralls: coverage
+    cover: coverage
+    coveralls: coverage<5.0
     coveralls: coveralls
 
 commands=
@@ -35,7 +36,7 @@ commands=
     docs: {envbindir}/sphinx-build {toxinidir}/docs/ {toxinidir}/build/sphinx {posargs:}
 
 [testenv:coveralls]
-passenv=TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv=TRAVIS TRAVIS_*
 commands=
     coverage run --source clize -m unittest2
     coveralls


### PR DESCRIPTION
Pinned coverage<5.0 in coveralls workflow while coveralls-clients/coveralls-python#203 gets addressed.